### PR TITLE
A try to get rid of the appveyor build error.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ environment:
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda36-x64
     - PYTHON_VERSION: 3.7
-      MINICONDA: C:\Miniconda36-x64
+      MINICONDA: C:\Miniconda37-x64
     - PYTHON_VERSION: 3.8
-      MINICONDA: C:\Miniconda36-x64
+      MINICONDA: C:\Miniconda38-x64
     - PYTHON_VERSION: 3.9
-      MINICONDA: C:\Miniconda36-x64
+      MINICONDA: C:\Miniconda38-x64
 
 #configuration:
 #  - Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ environment:
     - PYTHON_VERSION: 3.5
       MINICONDA: C:\Miniconda35-x64
     - PYTHON_VERSION: 3.6
-      MINICONDA: C:\Miniconda36-x64
+      MINICONDA: C:\Miniconda38-x64
     - PYTHON_VERSION: 3.7
-      MINICONDA: C:\Miniconda37-x64
+      MINICONDA: C:\Miniconda38-x64
     - PYTHON_VERSION: 3.8
       MINICONDA: C:\Miniconda38-x64
     - PYTHON_VERSION: 3.9
@@ -23,7 +23,6 @@ environment:
 install:
  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
  - conda config --set always_yes yes --set changeps1 no
- - conda install charset-normalizer -f
  - conda update -q conda
  - conda info -a
  - "conda create -q -n build-environment python=%PYTHON_VERSION% numpy scipy matplotlib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
 install:
  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
  - conda config --set always_yes yes --set changeps1 no
+ - conda install charset-normalizer -f
  - conda update -q conda
  - conda info -a
  - "conda create -q -n build-environment python=%PYTHON_VERSION% numpy scipy matplotlib"


### PR DESCRIPTION
A look into https://www.appveyor.com/docs/windows-images-software/#miniconda shows that there are higher miniconda versions available. I think it's worth a try ;-). I don't know, if this folders are accessible for the used build account.